### PR TITLE
Removes the bullet rotation to fix lag on lower end computers.

### DIFF
--- a/projectderp/src/BulletManager.java
+++ b/projectderp/src/BulletManager.java
@@ -23,7 +23,7 @@ public class BulletManager {
 	
 	public void drawBullets(Graphics g) {
 		for (int i = 0; i < bullets.size(); i++) {
-			bullets.get(i).draw(g);
+			bullets.get(i).drawB(g);
 			//System.out.println("drawing");
 		}
 	}

--- a/projectderp/src/Sprite.java
+++ b/projectderp/src/Sprite.java
@@ -339,6 +339,18 @@ class Sprite {
         g2d.drawImage(imgSub[frame], tr, null);
     }
     
+    //***************************************************
+    //TEMPORARY SOLUTION TO FIX SHOOTING LAGGING THE GAME
+    //***************************************************
+    public void drawB(Graphics g) {
+        Graphics2D g2d = (Graphics2D) g;
+    	
+        tr.setTransform(flipValue, 0, 0, 1, flipReposition+posX, 0+posY);
+        //tr.rotate(rotation, frameWidth/2, frameHeight/2);
+        
+        g2d.drawImage(imgSub[frame], tr, null);
+    }
+    
     /**
      * Determines if Sprite is touching another Sprite.
      *


### PR DESCRIPTION
Quick fix only. If the rotation function cannot be enhanced to support
bullets, the bullet image will be changed to a round one and rotation
disabled for good, but as of now, we're looking into a better solution.
